### PR TITLE
fix content editable issues and overrendering

### DIFF
--- a/src/app/nodes.cljc
+++ b/src/app/nodes.cljc
@@ -1,4 +1,5 @@
 (ns app.nodes
+  (:import [hyperfiddle.electric Pending])
   (:require #?(:clj [app.xtdb-contrib :as db])
             #?(:clj [app.utils :as u])
             [hyperfiddle.electric :as e]
@@ -86,8 +87,11 @@
              db (new (db/latest-db> user/!xtdb))]
      (e/client
       (dom/link (dom/props {:rel :stylesheet :href "/nodes.css"}))
-      (dom/div (dom/props {:class "nodes"})
-               (dom/ul
-                (e/server
-                 (e/for-by :xt/id [{:keys [xt/id]} (e/offload #(root-nodes db))]
-                           (Node. id)))))))))
+       (try
+         (dom/div (dom/props {:class "nodes"})
+           (dom/ul
+             (e/server
+               (e/for-by :xt/id [{:keys [xt/id]} (root-nodes db) #_(e/offload #(root-nodes db))] ; Pending is causing over-rendering, fixme
+                 (Node. id)))))
+         (catch Pending _
+           (dom/props {:style {:background-color "yellow"}})))))))


### PR DESCRIPTION
* I resolved the content-editable issue by managing the innerText out of band of Electric, which is idiomatic when you want to do low-level things.
* The NPE was connected to the content-editable problem (the Electric DAG desyncing from the DOM due to the out of band mutation caused the NPE, and then future operations are undefined)
* Looked into the over-rendering, which was caused by e/offload. I just removed the offload for now while we look into this.